### PR TITLE
fix: lookup returns undefined, not void

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
 export const mimes: Record<string, string>;
-export function lookup(extension: string): string | void;
+export function lookup(extension: string): string | undefined;


### PR DESCRIPTION
In this context, the lookup function returning `undefined` is information - it is a union of Some(data) | None.

Void should be used for functions that really return **no** data.

This has practical implications as in typescript, a property typed `string | undefined` cannot have `string | void` assigned to it.

```
src/entity/create.ts:160:11 - error TS2322: Type 'string | void' is not assignable to type 'string | undefined'.
  Type 'void' is not assignable to type 'string | undefined'.

160           type: mrmime.lookup(name),
              ~~~~


Found 1 error in src/entity/create.ts:160
```
(mrmime@1.0.0, typescript@4.6.3)